### PR TITLE
new version :)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '3.0.5'
 
 gem 'sqlite3'
 
-gem 'iplogic'
+gem 'iplogic', '~> 0.1.4'
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     erubis (2.6.6)
       abstract (>= 1.0.0)
     i18n (0.5.0)
-    iplogic (0.1.3)
+    iplogic (0.1.4)
     mail (2.2.15)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -70,6 +70,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  iplogic
+  iplogic (~> 0.1.4)
   rails (= 3.0.5)
   sqlite3


### PR DESCRIPTION
I made the parsing a little more forgiving: a lot of the time you'll see ranges expressed with only a partial IP address, like `10.0.1/24`, or `10.10/16`.  Also, sometimes the whole netmask is put behind the `/`, like `10.0.1/255.255.255.0`.  iplogic 0.1.4 will parse these formats as well :)
